### PR TITLE
Added handling of vkontakte's failed response to longpoll

### DIFF
--- a/vk/bot_framework/extensions/polling.py
+++ b/vk/bot_framework/extensions/polling.py
@@ -14,13 +14,12 @@ class Polling(BaseExtension):
         self._longpoll: BotLongPoll = BotLongPoll(group_id, vk)
 
     async def get_events(self) -> typing.List:
-        events = await self._longpoll.listen()
-        return events
+        return await self._longpoll.listen()
 
     async def run(self, dp):
         await self._longpoll._prepare_longpoll()
+
         logger.info("Polling started!")
+
         while True:
-            events = await self.get_events()
-            if events:
-                await dp._process_events(events)
+            await dp._process_events(await self.get_events())

--- a/vk/longpoll/bot/longpoll.py
+++ b/vk/longpoll/bot/longpoll.py
@@ -95,7 +95,7 @@ class BotLongPoll(mixins.ContextInstanceMixin):
                 return []
 
             if "ts" not in updates or "updates" not in updates:
-                raise Exception("Vkontakte responded with incorrect reponse")
+                raise Exception("Vkontakte responded with incorrect response")
 
             self.ts = updates["ts"]
             


### PR DESCRIPTION
- Добавил обработку ответа с `failed` от ВКонтакте во время longpoll (в этом случае нет необходимости ждать 10 секунд). 
- Переписал функцию `listen`, чтобы она всегда возвращала список. Поэтому немного упростил код расширения
- Обновил немного типы в объекте longpoll

Тестов я особо не нашёл, поэтому проверил на примере `simple_bot.py` - всё работает как полагается.